### PR TITLE
Removal of Joule from Wallets section

### DIFF
--- a/index.html
+++ b/index.html
@@ -466,11 +466,6 @@
 													<td>Android</td>
 												</tr>
 												<tr>
-													<td><a href="https://lightningjoule.com/">Joule</a></td>
-													<td>Lightning as Website Plugin (Connect to own node)</td>
-													<td>Desktop</td>
-												</tr>
-												<tr>
 													<td><a href="https://github.com/ShahanaFarooqui/RTL">RTL</a></td>
 													<td>An easy to use interface for LND</td>
 													<td>Desktop</td>


### PR DESCRIPTION
Due to Decred Support, removal of Joule under Wallets Section.