### PR TITLE
Changed Azte Location to Worldwide

### DIFF
--- a/index.html
+++ b/index.html
@@ -1576,12 +1576,12 @@
 												<tr>
 													<td><a href="https://azte.co">Azte.co</a></td>
 													<td>The easiest way to buy bitcoin</td>
-													<td><em>Not Launched</em></td>
+													<td>Worldwide</td>
 												</tr>
 												<tr>
 													<td><a href="https://www.sbb.ch/en/station-services/services/further-services/ticket-machine-services/bitcoin.html">SBB Railway Station</a></td>
 													<td>Simple Top Ups at Ticket Machines</td>
-													<td><em>Switzerland</em></td>
+													<td>Switzerland</td>
 												</tr>
 											</tbody>
 										</table>


### PR DESCRIPTION
Due to Azte having vendor locations in multiple countries, changed location to Worldwide.

Also adjusted Italics on two lines.