### PR TITLE
Add Fold App as a Bitcoin Only certified Sats Back giftcard service

### DIFF
--- a/index.html
+++ b/index.html
@@ -1785,6 +1785,10 @@
 													<td>Pay Bills (Canada)</td>
 												</tr>
 												<tr>
+													<td><a href="https://foldapp.com/">Fold App</a></td>
+													<td>Get up to 20% cashback in bitcoin when you shop at your favorite retailers.</td>
+												</tr>
+												<tr>
 													<td><a href="	https://host4coins.net/">Host4Coins</a></td>
 													<td>VPS Hosting</td>
 												</tr>


### PR DESCRIPTION
I can confirm I've used Fold App since 2014 and they've always been Bitcoin Only!