### PR TITLE
Added Bitcoinheiros

### DIFF
--- a/index.html
+++ b/index.html
@@ -1470,6 +1470,10 @@
 													<td>Interviews by Trace Mayer</td>
 												</tr>
 												<tr>
+													<td><a href="https://bitcoinheiros.com/">Bitcoinheiros</a></td>
+													<td>Pure Bitcoin content in Brazilian Portuguese</td>
+												</tr>
+												<tr>
 													<td><a href="https://www.youtube.com/playlist?list=PLXebE1eEMGOTe6ipH9n2AmUE3uLaKEfXE">Bitcoin Matters</a></td>
 													<td>Conversations with <a href="https://twitter.com/Beautyon_?s=09">@Beautyon_</a></td>
 												</tr>


### PR DESCRIPTION
Bitcoinheiros is the main Brazilian podcast about Bitcoin. It has interviews, tutorials all things Bitcoin