### PR TITLE
Broken Link for veriphi.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -1377,7 +1377,7 @@
 													<td>Open Source Bitcoin Archive</td>
 												</tr>
 												<tr>
-													<td><a href="https://veriphi.io/Publications-1/">Veriphi</a></td>
+													<td><a href="https://veriphi.io/blog/">Veriphi</a></td>
 													<td>Bitcoin Tech Explained</td>
 												</tr>
 												<tr>


### PR DESCRIPTION
We have updated our website and have changed the "/publications" for "/blog" so the link has been broken. 

I've made the correction. 