### PR TITLE
Update SoCal Lightning Meetup Name & Website to BitDevsLA

### DIFF
--- a/index.html
+++ b/index.html
@@ -1026,8 +1026,8 @@
 												</tr>
 												<tr>
 													<td>USA</td>
-													<td><a href="https://www.meetup.com/SoCal-Lightning/">Los Angeles</a></td>
-													<td><a href="https://twitter.com/SoCalLightning/status/1171919340020518912?s=19">@SoCalLightning</a></td>
+													<td><a href="https://www.meetup.com/BitDevsLA/">Los Angeles</a></td>
+													<td><a href="https://twitter.com/BitDevsLA/status/1171919340020518912?s=19">@BitDevsLA</a></td>
 												</tr>
 												<tr>
 													<td>USA</td>


### PR DESCRIPTION
SoCal Lightning Meetup changed name to BitDevsLA

https://twitter.com/BitDevsLA/status/1226983153136353280