### PR TITLE
Nodes: Remove Casa Node

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,10 +284,6 @@
 											</thead>
 											<tbody>
 												<tr>
-													<td><a href="https://keys.casa/lightning-bitcoin-node/">Casa Node</a></td>
-													<td>Lightning Node</td>
-												</tr>
-												<tr>
 													<td><a href="http://mynodebtc.com/products/one">MyNode</a></td>
 													<td>Full Stack - Low Cost</td>
 												</tr>


### PR DESCRIPTION
Casa has stopped selling nodes as of 1/31/19

https://blog.keys.casa/casas-focus-on-bitcoin-security/