### PR TITLE
Added Brazil meetup

### DIFF
--- a/index.html
+++ b/index.html
@@ -895,6 +895,11 @@
 													<td><a href="https://twitter.com/stephanlivera/status/1160849438069231617">@stephanlivera</a></td>
 												</tr>
 												<tr>
+													<td>Brazil</td>
+													<td><a href="https://www.meetup.com/Bitcoin-Assembly/">Calgary</a></td>
+													<td><a href="https://twitter.com/ldecferreira/status/1231639710151380993">@BitcoinAssembly</a></td>
+												</tr>										
+												<tr>
 													<td>Canada</td>
 													<td><a href="https://www.meetup.com/yycbitcoin/">Calgary</a></td>
 													<td><a href="https://twitter.com/yycbitcoin/status/1171544885519761408">@yycbitcoin</a></td>


### PR DESCRIPTION
Bitcoin assembly is a bitcoin-only meetup in São Paulo

Meetup page:
https://www.meetup.com/Bitcoin-Assembly/

and twitter
https://twitter.com/BitcoinAssembly
organizer: https://twitter.com/ldecferreira