### PR TITLE
Add Bitrawr to list of bitcoin-only resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -1431,6 +1431,10 @@
 													<td><a href="https://whyholdbitcoin.com/resources/">Why Hold Bitcoin</a></td>
 													<td>Reviews, Guides &amp; Resources</td>
 												</tr>
+												<tr>
+													<td><a href="https:/bitrawr.com/">Bitrawr</a></td>
+													<td>Bitcoin Exchange, Wallet, & Mining Resource</td>
+												</tr>
 											</tbody>
 										</table>
 									</div>


### PR DESCRIPTION
Bitrawr, also a strictly "bitcoin only" resource helps people find the most reputable exchanges to transact within their countries. All countries listed. SSL secured site.
@bitrawr on Twitter