### PR TITLE
Update conference section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2136,11 +2136,7 @@
 												</tr>
 											</thead>
 											<tbody>
-												<tr>
-													<td><a href="https://bitcoinmeetup.info/">Bitcoin Only Meetup</a></td>
-													<td>Bangalore, India</td>
-													<td>2020 / Feb / 22-23rd</td>
-												</tr>
+												
 												
 												<tr>
 													<td><a href="https://portlandbitcoinconference.com/">Portland Bitcoin Conf</a></td>
@@ -2168,6 +2164,11 @@
 												</tr>
 											</thead>
 											<tbody>
+												<tr>
+													<td><a href="http://web.archive.org/web/20200321002405/https://bitcoinmeetup.info//">Bitcoin Only Meetup</a></td>
+													<td><a href="https://blr.bitcoinmeetup.info">Feb 2020</a></td>
+												</tr>
+												
 												<tr>
 													<td><a href="https://www.thelightningconference.com/">The Lightning Conference</a></td>
 													<td><a href="https://twitter.com/LNconf">2019</a></td>


### PR DESCRIPTION
Moved "Bitcoin Only Meetup" which was organized in India on 22-23 Feb 2020 to "looking back" section and linked to meetup info website