### PR TITLE
Add Swan Bitcoin to Buy Bitcoin Section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1829,6 +1829,11 @@
 													<td>USA</td>
 												</tr>
 												<tr>
+													<td><a href="https://www.swanbitcoin.com/">Swan Bitcoin</a></td>
+													<td>Auto-Buy Bitcoin Weekly, Bi-Weekly or Monthly</td>
+													<td>USA</td>
+												</tr>
+												<tr>
 													<td><a href="https://www.sbb.ch/en/station-services/services/further-services/ticket-machine-services/bitcoin.html">SBB Railway Station</a></td>
 													<td>Simple Top Ups at Ticket Machines</td>
 													<td>Switzerland</td>


### PR DESCRIPTION
Used the service and confirmed it is bitcoin-only. They are now out of beta.

Closes #168 