### PR TITLE
Remove BitKassa

### DIFF
--- a/index.html
+++ b/index.html
@@ -1849,11 +1849,6 @@
 													<td>Worldwide</td>
 												</tr>
 												<tr>
-													<td><a href="https://www.bitkassa.nl/en/">BitKassa</a></td>
-													<td>Buy & Sell Bitcoin</td>
-													<td>Europe</td>
-												</tr>
-												<tr>
 													<td><a href="https://bitonic.nl/">Bitonic</a></td>
 													<td>Buy and Sell Bitcoin</td>
 													<td>Netherlands</td>
@@ -2163,10 +2158,6 @@
 												</tr>
 											</thead>
 											<tbody>
-												<tr>
-													<td><a href="https://www.bitkassa.nl/en/accept-bitcoin">BitKassa</a></td>
-													<td>Payments Processor</td>
-												</tr>
 												<tr>
 													<td><a href="https://bullbitcoin.com/">BullBitcoin</a></td>
 													<td>Non-Custodial Bitcoin Services</td>


### PR DESCRIPTION
Confirmed closure May 17th per https://www.bitkassa.nl/.

Closes #187 