### PR TITLE
Add Meetup - Bitcoin Lab Berlin

### DIFF
--- a/index.html
+++ b/index.html
@@ -964,6 +964,11 @@
 													<td><a href="https://twitter.com/Bob_le_chinois/status/1131931954776039424">@Bob_le_chinois</a></td>
 												</tr>
 												<tr>
+													<td>Germany</td>
+													<td><a href="https://www.meetup.com/Bitcoin-Lab-Berlin/">Berlin</a></td>
+													<td><a href="https://twitter.com/fulmolightning/status/1192493355739025408">@FulmoLightning</a></td>
+												</tr>
+												<tr>
 													<td>Holland</td>
 													<td><a href="https://www.meetup.com/nl-NL/Bitcoin-Only-Amsterdam/">Amsterdam</a></td>
 													<td><a href="https://twitter.com/OnHodliday/status/1132220583134019584?s=20">@OnHodliday</a></td>


### PR DESCRIPTION
Closes #182 

I didn't see any comments to [this](https://twitter.com/6102bitcoin/status/1192860972907683840) regarding this meetup. But from what I can tell, looking at their meetup page and organizers' twitters, they are bitcoin only.