### PR TITLE
Spend Bitcoin Page Clean-Up

### DIFF
--- a/index.html
+++ b/index.html
@@ -1985,10 +1985,6 @@
 													<td>VPS Hosting</td>
 												</tr>
 												<tr>
-													<td><a href="https://kriptode.com">Kriptode</a></td>
-													<td>Lightning Tools</td>
-												</tr>
-												<tr>
 													<td><a href="https://lnsms.world">LNsms</a></td>
 													<td>Send texts worldwide and pay with Lightning</td>
 												</tr>
@@ -2015,10 +2011,6 @@
 												</tr>
 											</thead>
 											<tbody>
-												<tr>
-													<td><a href="https://kriptode.com">Kriptode</a></td>
-													<td>Lightning Games</td>
-												</tr>
 												<tr>
 													<td><a href="https://lngames.net/">LNgames.net</a></td>
 													<td>Lightning Games</td>
@@ -2076,10 +2068,6 @@
 													<td>A Bitcoin Friendly City</td>
 												</tr>
 												<tr>
-													<td><a href="https://bitcoinmeritbadge.com/">Bitcoin Merit Badge</a></td>
-													<td>Bitcoin Badges</td>
-												</tr>
-												<tr>
 													<td><a href="https://bitcoinshirt.co">Bitcoin Shirt</a></td>
 													<td>Bitcoin Merchandise</td>
 												</tr>
@@ -2102,10 +2090,6 @@
 												<tr>
 													<td><a href="https://diynodes.com/">DIYnodes</a></td>
 													<td>Bitcoin Nodes &amp; More</td>
-												</tr>
-												<tr>
-													<td><a href="https://koalastickers.com/">Koala Stickers</a></td>
-													<td>Stickers</td>
 												</tr>
 												<tr>
 													<td><a href="https://layeronebtc.com/">Layer One BTC</a></td>
@@ -2154,10 +2138,6 @@
 												<tr>
 													<td><a href="https://wearsmyliberty.com">Wears My Liberty</a></td>
 													<td>Liberty Shirts, Hats, Hoodies &amp; More</td>
-												</tr>
-												<tr>
-													<td><a href="https://whiterabbit.store">White Rabbit Store</a></td>
-													<td>Bitcoin Bookmarks &amp; Accessories</td>
 												</tr>
 											</tbody>
 										</table>


### PR DESCRIPTION
Removed dead website links:
Bitcoin Merit Badge (also no recent twitter activity)
Koala Stickers
White Rabbit Store (announced store closure on twitter)

Removed due to alts:
Kriptode (apps to convert alts to ln bitcoin)