### PR TITLE
Move 21 Lessons from Learning to Books

### DIFF
--- a/index.html
+++ b/index.html
@@ -1245,6 +1245,12 @@
 										</tr>
 									</thead>
 									<tbody>
+										
+										<tr>
+											<td><a href="https://21lessons.com/">21 Lessons</a></td>
+											<td>Superb Bitcoin Lessons</td>
+											<td><a href="https://twitter.com/dergigi">Gigi</a></td>
+										</tr>
 										<tr>
 											<td>The Bitcoin Standard (<a href="https://www.amazon.com/Bitcoin-Standard-Decentralized-Alternative-Central/dp/1119473861">Hardcopy</a>)</td>
 											<td>Essential reading.</td>
@@ -1401,10 +1407,6 @@
 												<tr>
 													<td><a href="https://10hoursofbitcoin.com/">10hoursofbitcoin</a></td>
 													<td>Links to 10h of Bitcoin Lessons</td>
-												</tr>
-												<tr>
-													<td><a href="https://dergigi.com/bitcoin/lessons/">21lessons</a></td>
-													<td>Superb Bitcoin Lessons (Audio <a href="https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_256---21-Lessons-of-the-Bitcoin-Rabbit-Hole---Chapter-1-e47u83">1</a>|<a href="https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_257---21-Lessons-of-the-Bitcoin-Rabbit-Hole---Chapter-2-e489f9">2</a>|<a href="https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_258---21-Lessons-of-the-Bitcoin-Rabbit-Hole---Chapter-3-e48kao">3</a>)</td>
 												</tr>
 												<tr>
 													<td><a href="https://medium.com/@pierre_rochard/understanding-the-technical-side-of-bitcoin-2c212dd65c09">Background Reading</a></td>


### PR DESCRIPTION
21lessons.com no longer has the articles and is a homepage for the book. The book section is a better place for it now.