### PR TITLE
Update description in HTML meta tags.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 		<title>Bitcoin Only</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no" />
-		<meta name="description" content="Tracking bitcoin only projects." />
+		<meta name="description" content="Bitcoin resources (meetups, books, wallets, podcasts, conferences and much more)." />
 		<meta property="og:image" content="https://bitcoin-only.com/assets/images/share.png" />
 		<meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="800" />
@@ -13,7 +13,7 @@
 		<meta property="twitter:card" content="summary_large_image">
 		<meta property="twitter:site" content="bitcoin-only">
 		<meta property="twitter:title" content="Bitcoin Only">
-		<meta property="twitter:description" content="Tracking bitcoin only projects.">
+		<meta property="twitter:description" content="Bitcoin resources (meetups, books, wallets, podcasts, conferences and much more).">
 		<meta property="twitter:creator" content="6102bitcoin">
 		<meta property="twitter:image:src" content="https://bitcoin-only.com/assets/images/share.png">
 		<meta property="twitter:domain" content="bitcoin-only.com">

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 		<title>Bitcoin Only</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width,initial-scale=1,user-scalable=no" />
-		<meta name="description" content="Bitcoin resources (meetups, books, wallets, podcasts, conferences and much more)." />
+		<meta name="description" content="Bitcoin Only resources including meetups, books, wallets, podcasts, conferences and much more." />
 		<meta property="og:image" content="https://bitcoin-only.com/assets/images/share.png" />
 		<meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="800" />

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 		<meta property="twitter:card" content="summary_large_image">
 		<meta property="twitter:site" content="bitcoin-only">
 		<meta property="twitter:title" content="Bitcoin Only">
-		<meta property="twitter:description" content="Bitcoin resources (meetups, books, wallets, podcasts, conferences and much more).">
+		<meta property="twitter:description" content="Bitcoin Only resources including meetups, books, wallets, podcasts, conferences and much more.">
 		<meta property="twitter:creator" content="6102bitcoin">
 		<meta property="twitter:image:src" content="https://bitcoin-only.com/assets/images/share.png">
 		<meta property="twitter:domain" content="bitcoin-only.com">


### PR DESCRIPTION
Whenever I share a link to Bitcoin Only on Twitter or an app like Telegram, the value of the `description` meta tag will often be used to render some kind of card:

This is Telegram, for example:
<img width="569" alt="sharing" src="https://user-images.githubusercontent.com/46851636/89693994-da47e580-d8d5-11ea-8c5f-9c4f0714ff6e.png">

While the current description isn't exactly inaccurate... I think we can do a better job of capturing how Bitcoin Only is so much more -- it's THE first place I often recommend to people starting to learn about Bitcoin and the overall ecosystem.

For now, I just copied the description of the GitHub repo -- I thought that was pretty great 😄 -- but this could certainly be open to suggestions.