### PR TITLE
Add Kiwicoin, New Zealand's only Bitcoin-only exchange.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2100,6 +2100,11 @@
 													<td>USA</td>
 												</tr>
 												<tr>
+													<td><a href="https://kiwi-coin.com/">Kiwicoin</a></td>
+													<td>Buy & Sell</td>
+													<td>New Zealand</td>
+												</tr>
+												<tr>
 													<td><a href="https://river.com/">River Financial</a></td>
 													<td>Buy & Sell</td>
 													<td>USA</td>


### PR DESCRIPTION
Add Kiwicoin, New Zealand's only Bitcoin-only exchange.