### PR TITLE
Remove Blockstream Green Wallets

### DIFF
--- a/index.html
+++ b/index.html
@@ -399,7 +399,7 @@
 					<section id="wallets-section">
 						<div id="container39" class="container default full screen">
 							<div class="inner">
-								<p id="text141" class="style4"><span><code><strong>Getting Started:</strong></code> </span><br /><span>PC: Download <a target="_blank" href="https://bitcoin.org">Bitcoin Core</a></span><br /><span>Android: Download <a target="_blank" href="https://samouraiwallet.com/">Samourai Wallet</a></span><br /><span>iOS: Download <a target="_blank" href="https://blockstream.com/green/">Blockstream Green</a> <em>(Use Google Authentication not Email/Phone)</em></span></p>
+								<p id="text141" class="style4"><span><code><strong>Getting Started:</strong></code> </span><br /><span>PC: Download <a target="_blank" href="https://bitcoin.org">Bitcoin Core</a></span><br /><span>Android: Download <a target="_blank" href="https://samouraiwallet.com/">Samourai Wallet</a></span><br /></p>
 							</div>
 						</div>
 						<h2 id="text27" class="style3">Wallets</h2>
@@ -459,11 +459,6 @@
 													<td><a href="https://bitcoincore.org">Bitcoin Core</a></td>
 													<td>Full node &amp; Bitcoin wallet.</td>
 													<td>Desktop</td>
-												</tr>
-												<tr>
-													<td><a href="https://blockstream.com/green/">Blockstream Green</a></td>
-													<td>Easy to use wallet. Use Google Authentication not Email/Phone.</td>
-													<td>iOS &amp; Android</td>
 												</tr>
 												<tr>
 													<td><a href="https://unchained-capital.github.io/caravan/#/">Caravan</a></td>
@@ -635,7 +630,6 @@
 								<div>
 									<p id="text31">Android</p>
 									<p id="text32">
-										<span class="li"><a href="https://blockstream.com/green/">Blockstream Green</a> </span>
 										<span class="li"><a href="https://lightning-wallet.com/">BLW</a></span>
 										<span class="li"><a href="https://breez.technology">Breez</a></span>
 										<span class="li"><a href="https://keys.casa/keymaster/">Casa Keymaster</a></span>
@@ -655,7 +649,6 @@
 								<div>
 									<p id="text29">iOS</p>
 									<p id="text33">
-										<span class="li"><a href="https://blockstream.com/green/">Blockstream Green</a> </span>
 										<span class="li"><a href="https://breez.technology/">Breez</a></span>
 										<span class="li"><a href="https://keys.casa/keymaster/">Casa Keymaster</a></span>
 										<span class="li"><a href="https://testflight.apple.com/join/PuFnSqgi">Fully Noded (BETA)</a></span>


### PR DESCRIPTION
Closes #290 

Removes Android & iOS apps.

Checked the site for Green Address desktop wallet. Couldn't find any mention of tokens so left as-is.