### PR TITLE
Update Conferences

### DIFF
--- a/index.html
+++ b/index.html
@@ -2517,11 +2517,6 @@
 											</thead>
 											<tbody>
 												<tr>
-													<td><a href="https://gunsnbitcoin.com/bear-arms-2020/"> Bear Arms N' Bitcoin </a></td>
-													<td>Texas, USA</td>
-													<td>2020 / Sep / 19-20th</td>
-												</tr>
-												<tr>
 													<td><a href="https://portlandbitcoinconference.com/">Portland Bitcoin Conf</a></td>
 													<td>Portland, USA</td>
 													<td>2020 / Oct / 25th</td>
@@ -2561,10 +2556,6 @@
 												<tr>
 													<td><a href="https://portlandbitcoinconference.com/">Portland Bitcoin Conf</a></td>
 													<td><a href="https://www.pscp.tv/Brucefitter/1RDGlvOvBozxL">2019</a></td>
-												</tr>
-												<tr>
-													<td><a href="https://moneybadger.events/">Money Badger</a></td>
-													<td>None Found</td>
 												</tr>
 												<tr>
 													<td><a href="https://www.advancingbitcoin.com/">Advancing Bitcoin</a></td>


### PR DESCRIPTION
Bear Arms & Bitcoin - Removed from upcoming events since it has passed.

Money Badger - Removed from Looking Back. Dead link.
