### PR TITLE
Update 'Bitcoin Q & A' links

### DIFF
--- a/pages/learning-resources.vue
+++ b/pages/learning-resources.vue
@@ -255,7 +255,7 @@ export default {
 				},
 				{
 					title: 'Bitcoin Q & A',
-					link: 'https://www.bitcoinqna.com/',
+					link: 'https://bitcoiner.guide/qna/',
 					description: 'Extensive questions & answers'
 				},
 				{

--- a/pages/privacy.vue
+++ b/pages/privacy.vue
@@ -189,7 +189,7 @@ export default {
 			otherInfo: [
 				{
 					title: '10 Tips For Interacting With Bitcoin more Privately',
-					link: 'https://www.bitcoinqna.com/post/10-tips-for-interacting-with-bitcoin-more-privately',
+					link: 'https://bitcoiner.guide/privacytips/',
 					author: 'Bitcoin Q+A',
 					authorLink: 'https://twitter.com/BitcoinQ_A'
 				},


### PR DESCRIPTION
'Bitcoin Q & A' changed the domain from https://www.bitcoinqna.com/ to https://bitcoiner.guide/qna/.