### PR TITLE
Add Bitkipi

### DIFF
--- a/pages/get-bitcoin.vue
+++ b/pages/get-bitcoin.vue
@@ -184,6 +184,13 @@ export default {
 					autoDca: 'No'
 				},
 				{
+					title: 'Bitkipi',
+					link: 'https://bitkipi.com/',
+					description: 'Buy',
+					location: 'EU',
+					autoDca: 'Yes'
+				},
+				{
 					title: 'Bitonic',
 					link: 'https://bitonic.nl/',
 					description: 'Buy & Sell',


### PR DESCRIPTION
Hi,

Bitkipi is a new mobile app to buy bitcoin (only) directly into self custody. Available in Europe.