### PR TITLE
Update conferences.vue

### DIFF
--- a/pages/conferences.vue
+++ b/pages/conferences.vue
@@ -85,16 +85,34 @@ export default {
 					dates: '2022 / Feb / 19th'
 				},
 				{
+					title: 'Advancing Bitcoin',
+					link: 'https://www.advancingbitcoin.com/',
+					location: 'London / UK',
+					dates: '2022 / Mar / 3rd-4th'
+				},
+				{
+					title: 'Unconfiscatable',
+					link: 'https://unconfiscatable.com/',
+					location: 'Las Vegas, NV / USA',
+					dates: '2022 / Mar / 3rd-6th'
+				},
+				{
+					title: 'Empower: Energizing Bitcoin',
+					link: 'https://www.digitalwildcatters.com/empower-energizing-bitcoin/',
+					location: 'Houston, TX / USA',
+					dates: '2022 / Mar / 30th-31st'
+				},
+				{
 					title: 'Bitcoin 2022',
 					link: 'https://b.tc/conference',
-					location: 'TBD',
-					dates: '2022 / Apr / 6-9th'
+					location: 'Miami, FL / USA',
+					dates: '2022 / Apr / 6th-9th'
 				},
 				{
 					title: 'Bit Block Boom!',
 					link: 'https://bitblockboom.com/',
 					location: 'Austin, TX / USA',
-					dates: '2022 / Aug / 25-28th'
+					dates: '2022 / Aug / 25th-28th'
 				},
 				
 			],


### PR DESCRIPTION
Adds 3 bitcoin only conferences to the 'upcoming' list: 'Advancing Bitcoin', 'Unconfiscatable', and 'Empower: Energizing Bitcoin.'

Updates location of 'Bitcoin 2022' from 'TBD' to 'Miami, FL / USA'.

Updates date format (from 3-6th to 3rd-6th etc) for all conferences in 'upcoming' section.