### PR TITLE
Update RaspiBolt URL & description

### DIFF
--- a/pages/hardware.vue
+++ b/pages/hardware.vue
@@ -143,8 +143,8 @@ export default {
 				},
 				{
 					title: 'Raspibolt',
-					link: 'https://stadicus.github.io/RaspiBolt/',
-					description: 'Lightning node (Pi3 / Pi4)'
+					link: 'https://raspibolt.org/',
+					description: 'Bitcoin & Lightning node, manual installation guide for Debian-based OS'
 				},
 				{
 					title: 'RoninDojo',

--- a/pages/hardware.vue
+++ b/pages/hardware.vue
@@ -142,7 +142,7 @@ export default {
 					description: 'Full node with API (PC / Pi4)'
 				},
 				{
-					title: 'Raspibolt',
+					title: 'RaspiBolt',
 					link: 'https://raspibolt.org/',
 					description: 'Bitcoin & Lightning node, manual installation guide for Debian-based OS'
 				},


### PR DESCRIPTION
This PR makes 3 small changes to the RaspiBolt entry in the "Hardware" section

* Change the name to RaspiBolt (capital B)
* The RaspiBolt guide has now its own URL at raspibolt.org
* I also updated the short description to better highlight the specificities of the project.

Thanks!