### PR TITLE
Fix link to detbtc.com

### DIFF
--- a/pages/meetups.vue
+++ b/pages/meetups.vue
@@ -823,7 +823,7 @@ export default {
 					country: 'USA',
 					city: 'Detroit',
 					region: 'Michigan',
-					link: 'detbtc.com',
+					link: 'https://detbtc.com',
 					organizer: '@detbtc',
 					organizerLink: 'https://twitter.com/detbtc'
 				},


### PR DESCRIPTION
The link was missing the scheme and resolving as a relative link.