### PR TITLE
Meetups | Add kongerik.et (plebs.city) meetups

### DIFF
--- a/pages/meetups.vue
+++ b/pages/meetups.vue
@@ -613,6 +613,13 @@ export default {
 				},
 				{
 					country: 'Norway',
+					city: 'Bergen',
+					link: 'https://www.kongerik.et/arrangementer',
+					organizer: '@EuroDale',
+					organizerLink: 'https://twitter.com/EuroDale',
+				},				
+				{
+					country: 'Norway',
 					city: 'Oslo',
 					link: 'https://www.meetup.com/Oslo-Bitcoin-First-Meetup-Group/',
 					organizer: '@sikanderlhote',


### PR DESCRIPTION
[kongerik.et](https://www.kongerik.et/) (plebs.city) is a fast-growing Bitcoin-only group based
out of Norway. (Also see their [YouTube channel](https://www.youtube.com/c/PlebsCity/videos).)

This change adds a link to their main [meetups page](https://www.kongerik.et/arrangementer).