### PR TITLE
Updated Old City Bitcoiners about link.

### DIFF
--- a/pages/meetups.vue
+++ b/pages/meetups.vue
@@ -1133,7 +1133,7 @@ export default {
 					country: 'USA',
 					city: 'St. Augustine',
 					region: 'Florida',
-					link: 'https://oldcity-bitcoiners.info/introducing-oldcity-bitcoiners/',
+					link: 'https://www.oldcity-bitcoiners.info/about/',
 					organizer: '@OldCityBitcoin',
 					organizerLink: 'https://twitter.com/OldCityBitcoin/status/1374379639632629768'
 				},


### PR DESCRIPTION
I changed the navigation on the website such that /about is the main article. I'll be adding redirects on the website so /introducing-oldcity-bitcoiners/ go to /about. Just wanted to correct external links so clients can avoid redirects.