### PR TITLE
Add Bitcoin and the Trust Problem into Books

### DIFF
--- a/pages/books.vue
+++ b/pages/books.vue
@@ -103,6 +103,26 @@ export default {
 						}
 					]
 				},
+								{
+					title: 'Bitcoin and the Trust Problem',
+					synopsis: 'Society and Trust',
+					authors: [
+						{
+							name: 'Karo Zagorus',
+							link: 'https://twitter.com/btcdragonlord'
+						}
+					],
+					purchaseLinks: [
+						{
+							title: 'Amazon',
+							link: 'https://www.amazon.com/Bitcoin-Trust-Problem-bitcoin-fixing/dp/9916723567/'
+						},
+						{
+							title: 'Publisher',
+							link: 'https://bitcoinbook.shop/'
+						}
+					]
+				},
 				{
 					title: 'Bitcoin Money',
 					synopsis: 'Bitcoin story book for kids',


### PR DESCRIPTION
Finally it is released now, it will be present on both Amazon and Konsensus Network's bitcoin bookstore page. This Thesis is already present within the research section of Bitcoin-Only.com, it's now time to add it to the book section also now!