### PR TITLE
Update munich meetups

### DIFF
--- a/pages/meetups.vue
+++ b/pages/meetups.vue
@@ -456,7 +456,15 @@ export default {
 					region: 'Bayern',
 					city: 'München',
 					link: 'https://www.meetup.com/de-DE/Bitcoin-Munich/',
-					organizer: 'Unknown',
+					organizer: 'Bitcoin Munich',
+					organizerLink: 'https://x.com/bitcoinmuc'
+				},
+				{
+					country: 'Germany',
+					region: 'Bayern',
+					city: 'München',
+					link: 'http://t.me/EinundzwanzigM',
+					organizer: 'Einundzwanzig München',
 					organizerLink: 'https://einundzwanzig.space/meetups/'
 				},
 				{


### PR DESCRIPTION
In munich there are actually 2 different independent meetups. The traditional munich bitcoin meetup and the newer one from the einundzwanzig community.