### PR TITLE
Add BitcoinVN (Vietnam)

### DIFF
--- a/pages/get-bitcoin.vue
+++ b/pages/get-bitcoin.vue
@@ -176,6 +176,13 @@ export default {
 					autoDca: 'No'
 				},
 				{
+					title: 'BitcoinVN',
+					link: 'https://bitcoinvn.io/',
+					description: 'Buy & Sell',
+					location: 'Vietnam',
+					autoDca: 'Yes'
+				},
+				{
 					title: 'Bitkipi',
 					link: 'https://bitkipi.com/',
 					description: 'Buy',


### PR DESCRIPTION
## Summary

Add [BitcoinVN](https://bitcoinvn.io/) to the "Buy (other)" section of the Get Bitcoin page.

- **BitcoinVN** is Vietnam's longest-running Bitcoin exchange, operating since 2014 (10+ years)
- Non-custodial instant exchange with Lightning Network support
- VND (Vietnamese Dong) fiat on/off ramp — currently the only Vietnam-specific entry on the page
- Supports automatic DCA (recurring Bitcoin purchases)