### PR TITLE
Update spend-bitcoin.vue

### DIFF
--- a/pages/spend-bitcoin.vue
+++ b/pages/spend-bitcoin.vue
@@ -146,11 +146,6 @@ export default {
 			],
 			tools: [
 				{
-					title: 'Bitscribble',
-					link: 'https://bitscribble.com/',
-					description: 'Write 40 bytes of data to the blockchain'
-				},
-				{
 					title: 'BTCmessage',
 					link: 'https://btcmessage.com/',
 					description: 'Write data into the blockchain with vanity addrs'


### PR DESCRIPTION
Remove bitscribble as it is no longer functional.  The https://x.com/bitscribble_btc account has not shown any activity since 9:01 AM · Jul 19, 2019.