### PR TITLE
Add OpenBitcoin to Explorers & Dashboards

### DIFF
--- a/app/data/explorers-dashboards.js
+++ b/app/data/explorers-dashboards.js
@@ -20,6 +20,11 @@ export const explorers = [
 		description: 'Open source Bitcoin explorer',
 	},
 	{
+		title: 'OpenBitcoin',
+		link: 'https://openbitcoin.com/',
+		description: 'Open source Bitcoin explorer & tools',
+	},
+	{
 		title: 'Yogh Explorer',
 		link: 'https://yogh.io/',
 		description: 'Bitcoin blockchain reader',


### PR DESCRIPTION
Adds OpenBitcoin.com to the Explorers & Dashboards list, as suggested in #960. Opening it as a PR so there is nothing left to do on your side.

**What it is:** a bitcoin-only block explorer and tool collection served entirely from its own Bitcoin Core full node and its own address index, with no third-party blockchain API. Address, transaction and block lookups, a reachable-node census from its own P2P crawler, a rich list with published methodology, fee tools, a halving countdown, and plain-English guides.

**Open source (MIT):**
- website: https://github.com/openbitcoincom/openbitcoin-site
- node crawler behind /nodes: https://github.com/openbitcoincom/node-crawler
- address index and rich list: https://github.com/openbitcoincom/address-index

The hosted service's operational layer (rate limiting, caching, abuse defenses) stays private, so the description says "open source Bitcoin explorer & tools" rather than claiming the whole stack.

Entry placed alphabetically between Mempool.space and Yogh Explorer, matching the existing format. Verified against the repo's Prettier config (tabs, single quotes, no semicolons, 120 width).